### PR TITLE
Change server_token location

### DIFF
--- a/volumes/conf.d/nginx.conf
+++ b/volumes/conf.d/nginx.conf
@@ -1,0 +1,2 @@
+#worker_processes   16;
+server_tokens       off;

--- a/volumes/conf.d/server_tokens.conf
+++ b/volumes/conf.d/server_tokens.conf
@@ -1,1 +1,0 @@
-server_tokens off;


### PR DESCRIPTION
Change server_token location in order to hide nginx version. 

File server_token.conf was not working and was displaying nginx version.